### PR TITLE
Refactored response types

### DIFF
--- a/src/main/java/com/mtatgc/bookshelfms/controller/BookController.java
+++ b/src/main/java/com/mtatgc/bookshelfms/controller/BookController.java
@@ -22,31 +22,31 @@ public class BookController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<String> getBook(@PathVariable Long id) {
+    public ResponseEntity<Book> getBook(@PathVariable Long id) {
         Book book = bookService.getBook(id);
         if (book == null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
-        return ResponseEntity.ok(book.toString());
+        return ResponseEntity.ok(book);
     }
 
     @GetMapping()
-    public ResponseEntity<String> getAllBooks() {
+    public ResponseEntity<Iterable<Book>> getAllBooks() {
         Iterable<Book> listOfBooks = bookService.getAllBooks();
-        return ResponseEntity.ok(listOfBooks.toString());
+        return ResponseEntity.ok(listOfBooks);
     }
 
     @PostMapping
-    public ResponseEntity<String> createBook(@Valid @RequestBody Book book) {
+    public ResponseEntity<Object> createBook(@Valid @RequestBody Book book) {
         if (bookService.getBook(book.getId()) != null) {
             return ResponseEntity.badRequest().body("This ID already exists");
         }
         Book updatedBook = bookService.createBook(book);
-        return ResponseEntity.ok(updatedBook.toString());
+        return ResponseEntity.status(HttpStatus.CREATED).body(updatedBook);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<String> updateBook(@PathVariable Long id, @RequestBody Book book) {
+    public ResponseEntity<Object> updateBook(@PathVariable Long id, @RequestBody Book book) {
         Book originalBook = bookService.getBook(id);
         if (originalBook == null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
@@ -73,17 +73,17 @@ public class BookController {
         }
 
         bookService.saveBook(originalBook);
-        return ResponseEntity.ok(originalBook.toString());
+        return ResponseEntity.ok(originalBook);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<String> deleteBook(@PathVariable Long id) {
+    public ResponseEntity<Book> deleteBook(@PathVariable Long id) {
         bookService.deleteBook(id);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     @DeleteMapping()
-    public ResponseEntity<String> deleteAllBooks() {
+    public ResponseEntity<Book> deleteAllBooks() {
         bookService.deleteAllBooks();
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }

--- a/src/main/java/com/mtatgc/bookshelfms/controller/BookController.java
+++ b/src/main/java/com/mtatgc/bookshelfms/controller/BookController.java
@@ -6,7 +6,14 @@ import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * This controller accepts, handles, and responds to HTTP requests from endpoints that deal with books

--- a/src/main/java/com/mtatgc/bookshelfms/model/Book.java
+++ b/src/main/java/com/mtatgc/bookshelfms/model/Book.java
@@ -77,10 +77,4 @@ public class Book {
     public void setPublishedDate(LocalDate publishedDate) {
         this.publishedDate = publishedDate;
     }
-
-    @Override
-    public String toString() {
-        return "id: " + this.id + "\n" + "author_id: " + this.authorId + "\n" + "genre: " + this.genre
-               + "\n" + "published_date: " + this.publishedDate + "\n" + "title: " + this.title + "\n";
-    }
 }

--- a/src/test/java/com/mtatgc/bookshelfms/controller/BookControllerTests.java
+++ b/src/test/java/com/mtatgc/bookshelfms/controller/BookControllerTests.java
@@ -22,7 +22,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BookController.class)
 public class BookControllerTests {


### PR DESCRIPTION
**Summary**
- Refactor response types from `ResponseEntity<String>` to `ResponseEntity<Book>` or `ResponseEntity<Book>`
     - This allows Spring MVC to handle the JSON serialization and deserialization instead of using our custom `toString()` method (which can be error prone and not readable)
- Update POST endpoint to return `201` (CREATED) instead of `200` (OK)
- Remove `asJsonString()` test helper fxn since we can use the injected ObjectMapper's `writeValueAsString()` method instead
- Notice sometimes I assert on individual JSON properties with `jsonPath()` and sometimes I assert the whole JSON object with `writeValueAsString()`. Either can be used, both just allow more flexibility (and sometimes less code :-))